### PR TITLE
Avoid scientific numbers on the y axis

### DIFF
--- a/web/ui.js
+++ b/web/ui.js
@@ -232,6 +232,11 @@ $(function() {
                           $(element[0]).text(parseFloat(item.datapoint[1]).toFixed(8));
                         }
                     },
+                    yaxis: {
+                        tickFormatter: function(val, axis) {
+                          return rnd8(val);
+                        }
+                    },
                     xaxis: {
                         mode: "time",
                         timeformat: "%b %e\n%H:%M",


### PR DESCRIPTION
Small values on the Y axis might be displayed in scientific format. This pull request makes sure that the number is formatted correctly.

Old situation:
![yaxis](https://user-images.githubusercontent.com/2099087/34801540-8eaedc92-f669-11e7-8bee-31a828b25248.png)

New situation:
![new xaxis](https://user-images.githubusercontent.com/2099087/34801712-6a9a6e06-f66a-11e7-8c26-41c485f36b66.png)
