### PR TITLE
Show more information in the tooltips

### DIFF
--- a/web/ui.js
+++ b/web/ui.js
@@ -241,13 +241,7 @@ $(function() {
                     },
                     tooltip: {
                         show: true,
-                        content: "%y",
-                        onHover: function(item, element) {
-                          // The tooltip plugin does not provide an API to customize the
-                          // formatting string per data series, so we have to fix up the
-                          // formatting after the fact like this.
-                          $(element[0]).text(parseFloat(item.datapoint[1]).toFixed(8));
-                        }
+                        content: "%s: %y @ %x"
                     },
                     yaxis: {
                         tickFormatter: function(val, axis) {
@@ -540,6 +534,17 @@ $(function() {
                         xaxis: {
                             ticks: ticks,
                         },
+                        yaxis: {
+                            tickFormatter: function (val, axis) {
+                                if (axis.n === 1) {
+                                    return rnd8(val);
+                                } else if (axis.n === 2) {
+                                    return parseFloat(val).toFixed(2);
+                                } else {
+                                    return val;
+                                }
+                            }
+                        },
                         yaxes: [{
                             position: "left",
                             min: min,
@@ -559,22 +564,7 @@ $(function() {
                         },
                         tooltip: {
                             show: true,
-                            content: "%y.8",
-                            onHover: function(item, element) {
-                              // The tooltip plugin does not provide an API to customize the
-                              // formatting string per data series, so we have to fix up the
-                              // formatting after the fact like this.
-                              switch (item.seriesIndex) {
-                              case 1:
-                                // These are percentages, two decimal points of precision is enough.
-                                $(element[0]).text(parseFloat(element[0].innerText).toFixed(2));
-                                break;
-                              case 2:
-                                // These are just integers, no need for decimal zeros.
-                                $(element[0]).text(parseInt(element[0].innerText));
-                                break;
-                              }
-                            }
+                            content: "%s: %y"
                         },
                         series: {
                             bars: {


### PR DESCRIPTION
tickFormatter formats the %x and %y values as well, so we can drop
the onHover hacks.